### PR TITLE
boj 2151 거울 설치

### DIFF
--- a/bfs/2151.cpp
+++ b/bfs/2151.cpp
@@ -1,0 +1,96 @@
+#include <iostream>
+#include <queue>
+#define MAX 51
+using namespace std;
+typedef pair<pair<int, int>, pair<int, int> > pii;
+
+struct cmp {
+	bool operator()(pii a, pii b) {
+		return a.second.second > b.second.second;
+	}
+};
+
+char list[MAX][MAX];
+bool visit[MAX][MAX][4][MAX * 2];
+int direct[4][2] = { {0,1},{1,0},{0,-1},{-1,0} };
+int N, sx, sy, ex, ey;
+
+int bfs() {
+	int ans = 1e9;
+
+	priority_queue<pii, vector<pii>, cmp> q;
+	q.push({ {sx,sy}, {0,0} });
+	q.push({ {sx,sy}, {1,0} });
+	q.push({ {sx,sy}, {2,0} });
+	q.push({ {sx,sy}, {3,0} });
+	visit[sx][sy][0][0] = true;
+	visit[sx][sy][1][0] = true;
+	visit[sx][sy][2][0] = true;
+	visit[sx][sy][3][0] = true;
+
+	while (!q.empty()) {
+		int x = q.top().first.first;
+		int y = q.top().first.second;
+		int d = q.top().second.first;
+		int cnt = q.top().second.second;
+		q.pop();
+
+		if (x == ex && y == ey) {
+			return cnt;
+		}
+
+		int nx = x + direct[d][0];
+		int ny = y + direct[d][1];
+
+		if (nx < 0 || ny < 0 || nx >= N || ny >= N) continue;
+		if (list[nx][ny] == '*') continue;
+		if (list[nx][ny] == '!') {
+			int nd = (d + 1) % 4;
+			if (!visit[nx][ny][nd][cnt + 1]) {
+				q.push({ {nx,ny},{nd,cnt + 1} });
+				visit[nx][ny][nd][cnt + 1] = true;
+			}
+
+			nd = (d + 3) % 4;
+			if (!visit[nx][ny][nd][cnt + 1]) {
+				q.push({ {nx,ny},{nd,cnt + 1} });
+				visit[nx][ny][nd][cnt + 1] = true;
+			}
+		}
+
+		if (!visit[nx][ny][d][cnt]) {
+			q.push({ {nx,ny},{d,cnt} });
+			visit[nx][ny][d][cnt] = true;
+		}
+	}
+
+	return ans;
+}
+
+void func() {
+	cout << bfs() << '\n';
+}
+
+void input() {
+	bool flag = false;
+	cin >> N;
+	for (int i = 0; i < N; i++) {
+		cin >> list[i];
+		for (int j = 0; j < N; j++) {
+			if (list[i][j] == '#') {
+				!flag ? (sx = i, sy = j): (ex = i, ey = j);
+				flag = !flag;
+			}
+		}
+	}
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
bfs

## 풀이 방법
1. visit[x][y][d][cnt]: 좌표 (x, y)에 d방향으로 거울 cnt개 반사하여 왔을 때의 방문 처리
   + 아무리 많이 반사해도 MAX * 2번이라고 판단한다.
2. 맨 처음 문이 어디 있는지 모르기 때문에 모든 방향으로 queue에 push한다.
3. 해당 방향으로 next 좌표를 구하여 `!`일 때 90도 회전으로 나올 수 있는 두 가지를 모두 구한다.
4. next 좌표의 값이 `!`라도 거울을 놓지 않을 수 있으니 방향 변화 없이 next로 갈 경우도 구한다.
5. pq로 구현했으니 반대편 문에 도달하면 바로 cnt를 리턴한다.
