### PR TITLE
boj 19538 루머

### DIFF
--- a/bfs/19538.cpp
+++ b/bfs/19538.cpp
@@ -1,0 +1,77 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <queue>
+#include <cstring>
+#define MAX 200001
+using namespace std;
+
+queue<int> q;
+vector<int> graph[MAX];
+bool visit[MAX];
+int friends[MAX], conn[MAX], ans[MAX];
+int N, M;
+
+void bfs() {
+	for (int t = 1; !q.empty(); t++) {
+		int qsize = q.size();
+		while (qsize--) {
+			int x = q.front();
+			q.pop();
+
+			for (int i = 0; i < graph[x].size(); i++) {
+				int next = graph[x][i];
+
+				if (visit[next]) continue;
+
+				conn[next]++;
+				if (friends[next] <= conn[next] * 2) {
+					q.push(next);
+					ans[next] = t;
+					visit[next] = true;
+				}
+			}
+		}
+	}
+}
+
+void func() {
+	bfs();
+	for (int i = 1; i <= N; i++) {
+		cout << ans[i] << ' ';
+	}
+	cout << '\n';
+}
+
+void input() {
+	int x;
+	cin >> N;
+	for (int i = 1; i <= N; i++) {
+		while (1) {
+			cin >> x;
+			if (!x) break;
+
+			graph[i].push_back(x);
+			friends[i]++;
+		}
+	}
+
+	memset(ans, -1, sizeof(ans));
+	cin >> M;
+	while (M--) {
+		cin >> x;
+		q.push(x);
+		ans[x] = 0;
+		visit[x] = true;
+	}
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
bfs

## 풀이 방법
1. 입력을 받으면서 인접한 사람의 수를 friends에 카운팅한다.
2. ans를 -1로 초기화하고, 최초 유포자의 방문체크를 한다.
3. 최초 유포자를 시작으로 bfs를 순환하여 인접한 사람의 conn[next]를 증가한다.
4. conn[next] * 2가 friends[next] 이상이면 방문처리 후 queue에 넣는다.
   + queue에 넣으면서 ans[next]에 t를 저장한다.
