### PR TITLE
boj 24513 좀비 바이러스

### DIFF
--- a/bfs/24513.cpp
+++ b/bfs/24513.cpp
@@ -1,0 +1,98 @@
+#include <iostream>
+#include <algorithm>
+#include <queue>
+#define MAX 1001
+using namespace std;
+typedef pair<int, int> pii;
+
+queue<pii> oneq, twoq;
+int list[MAX][MAX], visit[MAX][MAX];
+int direct[4][2] = { {0,1},{1,0},{0,-1},{-1,0} };
+int N, M, ans[3];
+
+void bfs() {
+	for (int t = 1; !oneq.empty() || !twoq.empty(); t++) {
+		int oqsize = oneq.size();
+		int tqsize = twoq.size();
+
+		while (oqsize--) {
+			int x = oneq.front().first;
+			int y = oneq.front().second;
+			oneq.pop();
+
+			if (visit[x][y] == 3) {
+				visit[x][y] = -1;
+				continue;
+			}
+
+			ans[0]++;
+			visit[x][y] = -1;
+			for (int d = 0; d < 4; d++) {
+				int nx = x + direct[d][0];
+				int ny = y + direct[d][1];
+
+				if (nx < 0 || ny < 0 || nx >= N || ny >= M) continue;
+				if (visit[nx][ny] || list[nx][ny] == -1) continue;
+
+				oneq.push({ nx,ny });
+				visit[nx][ny] = 1;
+			}
+		}
+
+		while (tqsize--) {
+			int x = twoq.front().first;
+			int y = twoq.front().second;
+			twoq.pop();
+
+			ans[1]++;
+			visit[x][y] = -1;
+			for (int d = 0; d < 4; d++) {
+				int nx = x + direct[d][0];
+				int ny = y + direct[d][1];
+
+				if (nx < 0 || ny < 0 || nx >= N || ny >= M) continue;
+				if (visit[nx][ny] == 1) {
+					visit[nx][ny] = 3;
+					ans[2]++;
+					continue;
+				}
+				if (visit[nx][ny] || list[nx][ny] == -1) continue;
+				
+				twoq.push({ nx,ny });
+				visit[nx][ny] = 2;
+			}
+		}
+	}
+}
+
+void func() {
+	bfs();
+	cout << ans[0] << ' ' << ans[1] << ' ' << ans[2] << '\n';
+}
+
+void input() {
+	cin >> N >> M;
+	for (int i = 0; i < N; i++) {
+		for (int j = 0; j < M; j++) {
+			cin >> list[i][j];
+			if (list[i][j] == 1) {
+				oneq.push({ i,j });
+				visit[i][j] = -1;
+			}
+			else if (list[i][j] == 2) {
+				twoq.push({ i,j });
+				visit[i][j] = -1;
+			}
+		}
+	}
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
bfs

## 풀이 방법
1. 1번 바이러스는 oneq, 2번 바이러스는 twoq에 저장한다.
2. 방문 처리: 1번 바이러스는 1, 2번 바이러스는 2로 한다.
3. 1번 바이러스 먼저 bfs로 퍼뜨리고, oneq에서 뽑은 좌표가 3번 바이러스일 경우 방문 처리를 -1로 변경한다.
4. 그 다음 2번 바이러스를 bfs로 퍼뜨리고, 다음 좌표의 방문 처리가 1일 경우 3번 바이러스로 변환한다.
