### PR TITLE
boj 24447 알고리즘 수업 - 너비 우선 탐색 4

### DIFF
--- a/bfs/24447.cpp
+++ b/bfs/24447.cpp
@@ -1,0 +1,61 @@
+#include <iostream>
+#include <algorithm>
+#include <queue>
+#include <vector>
+#include <cstring>
+#define MAX 100001
+using namespace std;
+typedef long long ll;
+
+vector<int> graph[MAX];
+ll visit[MAX];
+int N, M, S;
+ll ans;
+
+void bfs() {
+	queue<int> q;
+	q.push(S);
+	visit[S] = 1;
+	ll cnt = 1;
+	for (ll t = 0; !q.empty(); t++) {
+		int qsize = q.size();
+		while (qsize--) {
+			int x = q.front();
+			q.pop();
+
+			ans += (t * visit[x]);
+			for (int i = 0; i < graph[x].size(); i++) {
+				int next = graph[x][i];
+
+				if (visit[next]) continue;
+				visit[next] = ++cnt;
+				q.push(next);
+			}
+		}
+	}
+}
+
+void func() {
+	bfs();
+	cout << ans << '\n';
+}
+
+void input() {
+	int u, v;
+	cin >> N >> M >> S;
+	while (M--) {
+		cin >> u >> v;
+		graph[u].push_back(v);
+		graph[v].push_back(u);
+	}
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
bfs

## 풀이 방법
1. visit을 방문 순서로 사용하며, 깊이는 t로 계산한다.
2. visit[S] = 1, S를 시작으로 bfs 순회한다.
3. queue에서 정점을 꺼낼 때마다 `방문 순서 * 깊이`를 계산하여 더한다.
   + S의 깊이는 0이므로 t = 0부터 시작한다.
