### PR TITLE
boj 11662 민호와 강호

### DIFF
--- a/ternarysearch/11662.cpp
+++ b/ternarysearch/11662.cpp
@@ -1,0 +1,64 @@
+#include <iostream>
+#include <algorithm>
+#include <cmath>
+using namespace std;
+typedef pair<double, double> pdd;
+
+typedef struct Point {
+	double x1, y1, x2, y2;
+}Point;
+
+Point a, b;
+
+double getDis(pdd p, pdd q) {
+	return sqrt((p.first - q.first) * (p.first - q.first) + (p.second - q.second) * (p.second - q.second));
+}
+
+pdd getNextPos(Point p, double per) {
+	return { p.x1 + (p.x2 - p.x1) * per, p.y1 + (p.y2 - p.y1) * per };
+}
+
+void func() {
+	double l = 0;
+	double r = 1;
+	double ans = 1e9;
+	while (r - l >= 1e-8) {
+		double p = (l * 2 + r) / 3.0;
+		double q = (l + r * 2) / 3.0;
+
+		pdd ap = getNextPos(a, p);
+		pdd aq = getNextPos(a, q);
+		pdd bp = getNextPos(b, p);
+		pdd bq = getNextPos(b, q);
+
+		double pDis = getDis(ap, bp);
+		double qDis = getDis(aq, bq);
+
+		ans = min(ans, min(pDis, qDis));
+
+		if (pDis < qDis) {
+			r = q;
+		}
+		else {
+			l = p;
+		}
+	}
+
+	cout << fixed;
+	cout.precision(7);
+	cout << ans << '\n';
+}
+
+void input() {
+	cin >> a.x1 >> a.y1 >> a.x2 >> a.y2 >> b.x1 >> b.y1 >> b.x2 >> b.y2;
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
ternary search

## 풀이 방법
1. 삼분 탐색을 이용하여 p%, q%씩 이동한 좌표의 거리를 비교한다.
2. 거리에 따라 구간을 좁힌다.
3. 오차가 1e-6까지 허용되므로 여유롭게 `r - l >= 1e-8` 일 동안 반복한다.
