### PR TITLE
boj 6988 타일 밟기

### DIFF
--- a/dp/6988.cpp
+++ b/dp/6988.cpp
@@ -1,0 +1,61 @@
+#include <iostream>
+#include <algorithm>
+#define MAX_N 3001
+#define MAXNUM 1000001
+using namespace std;
+typedef long long ll;
+
+int flag[MAXNUM];
+ll dp[MAX_N][MAX_N], list[MAX_N];
+int N;
+
+void func() {
+	ll ans = 0;
+	for (int i = 1; i <= N - 2; i++) {
+		for (int j = i + 1; j <= N - 1; j++) {
+			int diff = list[j] - list[i];
+			int next = list[j] + diff;
+
+			if (next >= MAXNUM) continue;
+			if (!flag[next]) continue;
+
+			dp[i][j] = list[i] + list[j];
+			ans = max(ans, dp[i][j]);
+		}
+	}
+
+	for (int i = 1; i <= N - 1; i++) {
+		for (int j = i + 1; j <= N; j++) {
+			if (!dp[i][j]) continue;
+
+			int diff = list[j] - list[i];
+			int next = list[j] + diff;
+
+			if (next >= MAXNUM) continue;
+			if (!flag[next]) continue;
+
+			dp[j][flag[next]] = dp[i][j] + list[flag[next]];
+			ans = max(ans, dp[j][flag[next]]);
+		}
+	}
+	
+	cout << ans << '\n';
+}
+
+void input() {
+	cin >> N;
+	for (int i = 1; i <= N; i++) {
+		cin >> list[i];
+		flag[list[i]] = i;
+	}
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
dp

## 풀이 방법
dp[i][j] : 이전 타일이 i번이고, 마지막으로 밟은 타일이 j번일 때 얻을 수 있는 최대 합
1. flag에는 입력으로 주어지는 수의 인덱스를 저장한다.
2. 2중 반복문을 돌려서 초기값을 세팅한다.
   + (i, j): (첫 타일, 중간 타일)
   + list[j] + diff가 입력 범위에 있고, flag에 인덱스가 저장되어 있다면 점수를 얻을 수 있는 타일이므로 dp[i][j]에 list[i] + list[j]를 저장한다.
   + dp[i][j]를 구하면서 ans를 갱신한다.
3. 2중 반복문을 다시 돌려서 초기값이 있는 타일 대상으로 나머지 값을 채운다.
   + (i, j, next): (이전 타일, 현재 타일, 다음 타일)
   + dp[i][j]는 이미 채워져 있으므로 dp[j][next의 인덱스]를 채운다.
      + next의 인덱스는 flag[next]
   + dp[j][flag[next]]에 dp[i][j] + list[flag[next]]를 계산하여 넣는다.
   + dp를 채워나가면서 ans를 갱신한다.
4. 마지막으로 ans를 출력한다.
   + 3개 연속된 타일을 밟을 수 없는 경우, 0을 출력하므로 ans는 처음에 0으로 초기화한다.
