### PR TITLE
boj 16198 에너지 모으기

### DIFF
--- a/dfs/16198.cpp
+++ b/dfs/16198.cpp
@@ -1,0 +1,59 @@
+#include <iostream>
+#include <algorithm>
+#define MAX 11
+using namespace std;
+
+int list[MAX], parent[2][MAX];
+int N;
+
+int find(int idx, int v) {
+	if (parent[idx][v] == v) return v;
+	else return find(idx, parent[idx][v]);
+}
+
+int dfs(int cnt) {
+	if (cnt == 2) return 0;
+
+	int ret = 0;
+	for (int i = 2; i <= N - 1; i++) {
+		if (parent[0][i] != i) continue;
+		parent[0][i] = parent[0][i - 1];
+		parent[1][i] = parent[1][i + 1];
+		int idx1 = find(0, i - 1);
+		int idx2 = find(1, i + 1);
+		ret = max(ret, dfs(cnt - 1) + list[idx1] * list[idx2]);
+		parent[0][i] = i;
+		parent[1][i] = i;
+	}
+
+	return ret;
+}
+
+void func() {
+	cout << dfs(N) << '\n';
+}
+
+void init() {
+	for (int i = 1; i <= N; i++) {
+		parent[0][i] = i;
+		parent[1][i] = i;
+	}
+}
+
+void input() {
+	cin >> N;
+	for (int i = 1; i <= N; i++) {
+		cin >> list[i];
+	}
+	init();
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
dfs, backtracking

## 풀이 방법
1. x - 1, x + 1의 인덱스를 파악할 수 있도록 parent 배열을 사용한다.
   + parent[0]: x - 1의 인덱스
   + parent[1]: x + 1의 인덱스
   + list배열의 원소를 제거하는 대신 인덱스를 이동시킨다.
2. 1, N번 원소는 제거할 수 없으므로 배열은 2 ~ N - 1만 순회한다.
3. find 함수를 이용하여 모을 수 있는 에너지를 구한다.
4. cnt는 배열에 남은 원소의 갯수이며, 2개 되었을 때 0을 리턴한다.
5. i번 원소를 제거했을 때의 최댓값을 구했다면 parent 배열을 원래대로 되돌린다.
