### PR TITLE
boj 19598 최소 회의실 개수

### DIFF
--- a/자료구조/19598.cpp
+++ b/자료구조/19598.cpp
@@ -1,0 +1,47 @@
+#include <iostream>
+#include <queue>
+#include <vector>
+#include <algorithm>
+#define MAX 100001
+using namespace std;
+typedef pair<int, int> pii;
+
+struct cmp {
+	bool operator()(int a, int b) {
+		return a > b;
+	}
+};
+
+priority_queue<int, vector<int>, cmp> q;
+pii list[MAX];
+int N;
+
+void func() {
+	int ans = 0;
+	for (int i = 0; i < N; i++) {
+		while (!q.empty() && q.top() <= list[i].first) q.pop();
+
+		q.push(list[i].second);
+		ans = max(ans, (int)q.size());
+	}
+
+	cout << ans << '\n';
+}
+
+void input() {
+	cin >> N;
+	for (int i = 0; i < N; i++) {
+		cin >> list[i].first >> list[i].second;
+	}
+	sort(list, list + N);
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
priority queue

## 풀이 방법
1. 입력을 회의 시작 순으로 오름차순 정렬한다.
2. 우선순위 큐에는 i번째 회의가 끝나는 시간을 넣는다.
3. 큐에 넣을 때마다 ans에 큐의 최대 크기를 갱신한다.
4. 큐에 push하기 전에 `i번째 회의의 시작 시간 >= q.top()`인 회의를 모두 제거한다.
