### PR TITLE
boj 1689 겹치는 선분

### DIFF
--- a/자료구조/1689.cpp
+++ b/자료구조/1689.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <algorithm>
+#include <queue>
+#define MAX 1000001
+using namespace std;
+typedef pair<int, int> pii;
+
+pii list[MAX];
+int N;
+
+void func() {
+	priority_queue<int, vector<int>, greater<int>> q;
+	q.push(list[0].second);
+	int ans = 1;
+	for (int i = 1; i < N; i++) {
+		while (!q.empty() && q.top() <= list[i].first) q.pop();
+
+		q.push(list[i].second);
+		ans = max(ans, (int)q.size());
+	}
+
+	cout << ans << '\n';
+}
+
+void input() {
+	cin >> N;
+	for (int i = 0; i < N; i++) {
+		cin >> list[i].first >> list[i].second;
+	}
+	sort(list, list + N);
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
priority queue

## 풀이 방법
#497 풀이와 동일
1. 입력을 선분의 시작 좌표를 기준으로 오름차순 정렬한다.
2. 우선순위 큐에는 i번째 선분이 끝나는 좌표를 넣는다.
3. 큐에 넣을 때마다 ans에 큐의 최대 크기를 갱신한다.
4. 큐에 push하기 전에 `i번째 선분의 시작 좌표 >= q.top()`인 선분을 모두 제거한다.
