### PR TITLE
boj 21318 피아노 체조

### DIFF
--- a/dp/21318.cpp
+++ b/dp/21318.cpp
@@ -1,0 +1,38 @@
+#include <iostream>
+#define MAX 100001
+using namespace std;
+
+int dp[MAX];
+int list[MAX];
+int N, M;
+
+void func() {
+	for (int i = 1; i <= N; i++) {
+		dp[i] += dp[i - 1];
+	}
+
+	int l, r;
+	cin >> M;
+	while (M--) {
+		cin >> l >> r;
+		cout << dp[r] - dp[l] << '\n';
+	}
+}
+
+void input() {
+	cin >> N;
+	for (int i = 1; i <= N; i++) {
+		cin >> list[i];
+		if (list[i] < list[i - 1]) dp[i] = 1;
+	}
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
dp, prefix sum

## 풀이 방법
1. 입력을 받으면서 list[i - 1]보다 작은 입력을 받았다면 dp[i]에 1을 추가한다.
2. dp 배열의 누적합을 구한다.
3. l번, r번 악보에서는 실수를 하지 않으므로 `dp[r] - dp[l]`을 출력한다.
   + `list[l] < list[l - 1]`일 경우가 있지만 l번 부터 연주하므로 실수했다고 할 수 없다.
