### PR TITLE
boj 8462 배열의 힘

### DIFF
--- a/offline-queries/8462.cpp
+++ b/offline-queries/8462.cpp
@@ -1,0 +1,87 @@
+#include <iostream>
+#include <algorithm>
+#include <cmath>
+#define MAX 100001
+#define MAXN 1000001
+using namespace std;
+typedef long long ll;
+
+typedef struct Point {
+	int l, r, idx;
+}Point;
+
+ll list[MAX], ans[MAX], cnt[MAXN];
+Point q[MAX];
+int N, M, sqrtN;
+
+bool cmp(Point a, Point b) {
+	int x = a.l / sqrtN;
+	int y = b.l / sqrtN;
+
+	if (x == y) return a.r < b.r;
+	else return x < y;
+}
+
+void func() {
+	int l = 0;
+	int r = 0;
+	ll ret = 0;
+	for (int i = 1; i <= M; i++) {
+		int nl = q[i].l;
+		int nr = q[i].r;
+		int idx = q[i].idx;
+
+		for (int j = l; j < nl; j++) {
+			ret -= (cnt[list[j]] * cnt[list[j]] * list[j]);
+			cnt[list[j]]--;
+			ret += (cnt[list[j]] * cnt[list[j]] * list[j]);
+		}
+		for (int j = l - 1; j >= nl; j--) {
+			ret -= (cnt[list[j]] * cnt[list[j]] * list[j]);
+			cnt[list[j]]++;
+			ret += (cnt[list[j]] * cnt[list[j]] * list[j]);
+		}
+		for (int j = r; j > nr; j--) {
+			ret -= (cnt[list[j]] * cnt[list[j]] * list[j]);
+			cnt[list[j]]--;
+			ret += (cnt[list[j]] * cnt[list[j]] * list[j]);
+		}
+		for (int j = r + 1; j <= nr; j++) {
+			ret -= (cnt[list[j]] * cnt[list[j]] * list[j]);
+			cnt[list[j]]++;
+			ret += (cnt[list[j]] * cnt[list[j]] * list[j]);
+		}
+
+		l = nl;
+		r = nr;
+		ans[idx] = ret;
+	}
+
+	for (int i = 1; i <= M; i++) {
+		cout << ans[i] << '\n';
+	}
+}
+
+void input() {
+	cin >> N >> M;
+	for (int i = 1; i <= N; i++) {
+		cin >> list[i];
+	}
+	sqrtN = sqrt(N);
+
+	for (int i = 1; i <= M; i++) {
+		cin >> q[i].l >> q[i].r;
+		q[i].idx = i;
+	}
+	sort(q + 1, q + 1 + M, cmp);
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
offline queries, mo's

## 풀이 방법
1. 오프라인 쿼리를 위해 쿼리 정보를 한번에 입력 받는다.
   + 정렬을 위해 인덱스도 같이 저장한다.
   + mo's 알고리즘으로 쿼리를 정렬한다.
2. 정렬된 쿼리를 하나씩 처리한다.
   + 새로운 범위의 수를 카운팅하기 전, 기존에 카운팅 되어있던 값을 제거해야 하므로 `cnt[x] * cnt[x] * x`를 미리 뺀다.
   + 새로운 범위에 대한 카운팅을 진행한다.
   + 새롭게 적용된 카운팅을 이용하여 다시 계산한 값 `cnt[x] * cnt[x] * x`을 다시 더한다.
