### PR TITLE
boj 12986 화려한 마을2

### DIFF
--- a/offline-queries/12986.cpp
+++ b/offline-queries/12986.cpp
@@ -1,0 +1,101 @@
+#include <iostream>
+#include <algorithm>
+#include <cmath>
+#define MAX 100001
+using namespace std;
+
+typedef struct Point {
+	int l, r, idx;
+}Point;
+
+Point q[MAX];
+int list[MAX], ans[MAX], cnt[MAX * 2], cntCnt[MAX];
+int N, M, sqrtN;
+
+bool cmp(Point a, Point b) {
+	int x = a.l / sqrtN;
+	int y = b.l / sqrtN;
+	if (x == y) return a.r < b.r;
+	else return x < y;
+}
+
+void func() {
+	int l = q[1].l;
+	int r = q[1].r;
+	int ret = 0;
+	for (int i = l; i <= r; i++) {
+		int x = list[i] + 100000;
+		if (cnt[x]) cntCnt[cnt[x]]--;
+		cnt[x]++;
+		cntCnt[cnt[x]]++;
+		ret = max(ret, cnt[x]);
+	}
+	ans[q[1].idx] = ret;
+
+	for (int i = 2; i <= M; i++) {
+		int nl = q[i].l;
+		int nr = q[i].r;
+		int idx = q[i].idx;
+
+		for (int j = l; j < nl; j++) {
+			int x = list[j] + 100000;
+			cntCnt[cnt[x]]--;
+			if (!cntCnt[cnt[x]] && ret == cnt[x]) ret--;
+			cnt[x]--;
+			cntCnt[cnt[x]]++;
+		}
+		for (int j = l - 1; j >= nl; j--) {
+			int x = list[j] + 100000;
+			if (cnt[x]) cntCnt[cnt[x]]--;
+			cnt[x]++;
+			cntCnt[cnt[x]]++;
+			ret = max(ret, cnt[x]);
+		}
+		for (int j = r; j > nr; j--) {
+			int x = list[j] + 100000;
+			cntCnt[cnt[x]]--;
+			if (!cntCnt[cnt[x]] && ret == cnt[x]) ret--;
+			cnt[x]--;
+			cntCnt[cnt[x]]++;
+		}
+		for (int j = r + 1; j <= nr; j++) {
+			int x = list[j] + 100000;
+			if (cnt[x]) cntCnt[cnt[x]]--;
+			cnt[x]++;
+			cntCnt[cnt[x]]++;
+			ret = max(ret, cnt[x]);
+		}
+
+		l = nl;
+		r = nr;
+		ans[idx] = ret;
+	}
+
+	for (int i = 1; i <= M; i++) {
+		cout << ans[i] << '\n';
+	}
+}
+
+void input() {
+	cin >> N >> M;
+	for (int i = 1; i <= N; i++) {
+		cin >> list[i];
+	}
+	sqrtN = sqrt(N);
+
+	for (int i = 1; i <= M; i++) {
+		cin >> q[i].l >> q[i].r;
+		q[i].idx = i;
+	}
+	sort(q + 1, q + 1 + M, cmp);
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
offline queries, mo's

## 풀이 방법
1. 오프라인 쿼리를 위해 쿼리 정보를 한번에 입력 받는다.
   + 정렬을 위해 인덱스도 같이 저장한다.
2. mo's 알고리즘으로 쿼리를 정렬한다.
3. 정렬된 쿼리를 하나씩 처리한다.
   + 단, 페인트의 밝기가 음수도 있으므로 +100000한 값을 인덱스로 사용한다.
   + 필요한 카운팅은 각 수들의 등장 횟수와 그 등장 횟수가 등장한 횟수다.
   + `l ~ r`의 범위에서 수의 카운트를 진행하고, cnt 또한 카운팅을 진행한다.
   + 새로운 `nl ~ nr` 범위에서 수를 지우기 전, cntCnt의 카운트를 1 감소한다.
   + 만약 해당 cntCnt가 0이 되었고, 그 카운트가 원래 최대 카운트였다면 ret을 1 감소한다.
   + 새로운 범위에 대한 카운팅을 진행한다.
   + 위 과정을 반복한다.
