### PR TITLE
boj 2934 LRH 식물

### DIFF
--- a/세그먼트 트리/2934.cpp
+++ b/세그먼트 트리/2934.cpp
@@ -1,0 +1,69 @@
+#include <iostream>
+#define MAX 100001
+using namespace std;
+
+int tree[MAX * 4], lazy[MAX * 4];
+int N;
+
+void lazyUpdate(int node, int s, int e) {
+	if (!lazy[node]) return;
+
+	tree[node] += lazy[node];
+	if (s != e) {
+		lazy[node * 2] += lazy[node];
+		lazy[node * 2 + 1] += lazy[node];
+	}
+	lazy[node] = 0;
+}
+
+void update(int node, int s, int e, int l, int r) {
+	lazyUpdate(node, s, e);
+	if (s > r || l > e) return;
+	if (l <= s && e <= r) {
+		lazy[node] += 1;
+		lazyUpdate(node, s, e);
+		return;
+	}
+
+	int m = (s + e) / 2;
+	update(node * 2, s, m, l, r);
+	update(node * 2 + 1, m + 1, e, l, r);
+	tree[node] = tree[node * 2] + tree[node * 2 + 1];
+}
+
+int query(int node, int s, int e, int idx) {
+	lazyUpdate(node, s, e);
+	if (idx < s || e < idx) return 0;
+	if (s == e) {
+		int ret = tree[node];
+		tree[node] = 0;
+		return ret;
+	}
+
+	int m = (s + e) / 2;
+	return query(node * 2, s, m, idx) + query(node * 2 + 1, m + 1, e, idx);
+}
+
+void func() {
+	int l, r;
+	for (int i = 0; i < N; i++) {
+		cin >> l >> r;
+		cout << query(1, 1, MAX - 1, l) + query(1, 1, MAX - 1, r) << '\n';
+
+		update(1, 1, MAX - 1, l + 1, r - 1);
+	}
+}
+
+void input() {
+	cin >> N;
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
segment tree with lazy propagation

## 풀이 방법
1. l, r번 인덱스의 누적 합을 구한다.
   + 꽃은 겹쳐서 피지 않으므로 합을 구한 후 0으로 변경한다.
2. `l + 1 ~ r - 1` 구간을 +1로 업데이트 한다.
   + 구간 업데이트이므로 lazy를 이용한다.
