### PR TITLE
boj 2086 피보나치 수의 합

### DIFF
--- a/분할정복/2086.cpp
+++ b/분할정복/2086.cpp
@@ -1,0 +1,49 @@
+#include <iostream>
+#include <vector>
+#define MOD 1000000000
+using namespace std;
+typedef long long ll;
+typedef vector<vector<ll> > vvll;
+
+vvll v = { {1,1},{1,0} };
+ll l, r;
+
+vvll mulMatrix(vvll a, vvll b) {
+	vvll ret = { {0,0},{0,0} };
+	for (int i = 0; i < 2; i++) {
+		for (int j = 0; j < 2; j++) {
+			for (int k = 0; k < 2; k++) {
+				ret[i][j] = (ret[i][j] + a[i][k] * b[k][j]) % MOD;
+			}
+		}
+	}
+
+	return ret;
+}
+
+vvll solve(ll n) {
+	if (n == 1LL) return v;
+
+	if (n % 2LL) {
+		vvll pre = solve(n - 1LL);
+		return mulMatrix(pre, v);
+	}
+	else {
+		vvll pre = solve(n / 2LL);
+		return mulMatrix(pre, pre);
+	}
+}
+
+void input() {
+	cin >> l >> r;
+	cout << (solve(r + 2)[0][1] - solve(l + 1)[0][1] + MOD) % MOD<< '\n';
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
divide and conquer, exponentiation by squaring

## 풀이 방법
1. `l ~ r`의 피보나치 수 합은 `r + 2번째 피보나치 수` - `l + 1번째 피보나치 수`로 구할 수 있다.
2. 현재 n이 홀수면 `solve(n - 1), v`의 곱을, 짝수면 `solve(n / 2), solve(n / 2)`의 곱을 구한다.
3. 출력은 `MOD 1000000000`으로 해야 하니 행렬을 곱하는 과정에서 mod 연산을 진행한다.
   + MOD 연산을 적용했으므로 값이 음수가 나올 수 있어 MOD를 더한 다음 % 연산을 진행한다.