### PR TITLE
boj 17410 수열과 쿼리 1.5

### DIFF
--- a/제곱근 분할법/17410.cpp
+++ b/제곱근 분할법/17410.cpp
@@ -1,0 +1,65 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <cmath>
+#define MAXN 100001
+#define MAXB 320
+using namespace std;
+
+vector<int> v[MAXB];
+int list[MAXN];
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	int N, M, sqrtN;
+	cin >> N;
+	for (int i = 0; i < N; i++) {
+		cin >> list[i];
+	}
+
+	sqrtN = 1000;
+	for (int i = 0; i < N; i++) {
+		v[i / sqrtN].push_back(list[i]);
+	}
+	for (int i = 0; i < MAXB; i++) {
+		sort(v[i].begin(), v[i].end());
+	}
+
+	int type, a, b, c;
+	cin >> M;
+	while (M--) {
+		cin >> type;
+		if (type == 2) {
+			cin >> a >> b >> c;
+			a--;
+			b--;
+
+			int ans = 0;
+			while (a % sqrtN && a <= b) {
+				if (list[a] > c) ans++;
+				a++;
+			}
+			while ((b + 1) % sqrtN && a <= b) {
+				if (list[b] > c) ans++;
+				b--;
+			}
+			while (a <= b) {
+				ans += (v[a / sqrtN].end() - upper_bound(v[a / sqrtN].begin(), v[a / sqrtN].end(), c));
+				a += sqrtN;
+			}
+
+			cout << ans << '\n';
+		}
+		else {
+			cin >> a >> b;
+			a--;
+			v[a / sqrtN].erase(lower_bound(v[a / sqrtN].begin(), v[a / sqrtN].end(), list[a]));
+			v[a / sqrtN].insert(lower_bound(v[a / sqrtN].begin(), v[a / sqrtN].end(), b), b);
+			list[a] = b;
+		}
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
square root decomposition

## 풀이 방법
1. 배열을 크기가 1000인 구간으로 나누어 각 구간에 맞는 벡터에 넣는다.
2. 벡터에 있는 수들을 오름차순으로 정렬한다.
3. `type == 1` 일 때, lower_bound를 이용하여 list[a]에 해당하는 수를 제외하고, b를 추가한다.
4. `type == 2` 일 때, 각 구간의 일부를 차지하는 a, b가 포함된 구간에서는 선형으로 c보다 큰 수를 찾는다.
   + 나머지는 upper_bound를 이용하여 구간 갯수 합을 더한다.

main에서 함수호출 하는 방식은 TLE
함수에 있는 코드들 전부 main으로 넣으니 AC
로직의 차이가 없는데 무슨 차이가 있는건지 모르겠다.