### PR TITLE
boj 2281 데스노트

### DIFF
--- a/dp/2281.cpp
+++ b/dp/2281.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <algorithm>
+#include <cstring>
+#define MAX 1001
+using namespace std;
+
+int dp[MAX][MAX], list[MAX];
+int N, M;
+
+int solve(int idx, int len) {
+	if (idx == N) return 0;
+
+	int& ret = dp[idx][len];
+	if (ret != -1) return ret;
+	
+	ret = (M - len + 1) * (M - len + 1) + solve(idx + 1, list[idx] + 1);
+	if (len + list[idx] <= M) {
+		ret = min(ret, solve(idx + 1, len + list[idx] + 1));
+	}
+
+	return ret;
+}
+
+void func() {
+	memset(dp, -1, sizeof(dp));
+	cout << solve(0, 0) << '\n';
+}
+
+void input() {
+	cin >> N >> M;
+	for (int i = 0; i < N; i++) {
+		cin >> list[i];
+	}
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
dp

## 풀이 방법
`dp[idx][len]: idx번째 이름을 적을 차례에 사용한 공간이 len일 때 남는 칸 수의 제곱의 합의 최댓값`
1. 어떤 경우에도 한 줄 건너뛰고 이름을 적을 수 있으므로 현재 남은 칸의 제곱을 최초 ret에 더한다.
   + 다음 이름은 idx + 1, 사용한 공간은 list[idx] + 1로 다음을 확인한다.
2. 현재 줄에 이름을 적을 수 있는 경우에는 현재 줄에 이름을 적고 최적의 해를 구한다.
   + 다음 이름은 idx + 1, 사용한 공간은 len + list[idx] + 1로 다음을 확인한다.
   + 마지막 줄은 남은 칸에 포함되지 않으므로 제곱을 더하지 않는다.
