### PR TITLE
boj 25307 시루의 백화점 구경

### DIFF
--- a/bfs/25307.cpp
+++ b/bfs/25307.cpp
@@ -1,0 +1,93 @@
+#include <iostream>
+#include <queue>
+#include <vector>
+#include <algorithm>
+#define MAX 2001
+using namespace std;
+typedef pair<int, int> pii;
+
+queue<pii> q, mq;
+vector<pii> v;
+int list[MAX][MAX];
+bool visit[MAX][MAX];
+int direct[4][2] = { {0,1},{1,0},{0,-1},{-1,0} };
+int N, M, K;
+
+void func() {
+	for (int t = 0; !q.empty(); t++) {
+		int qsize = q.size();
+		while (qsize--) {
+			int x = q.front().first;
+			int y = q.front().second;
+			q.pop();
+
+			if (list[x][y] == 2) {
+				cout << t << '\n';
+				return;
+			}
+
+			for (int d = 0; d < 4; d++) {
+				int nx = x + direct[d][0];
+				int ny = y + direct[d][1];
+
+				if (nx < 0 || ny < 0 || nx >= N || ny >= M) continue;
+				if (visit[nx][ny] || list[nx][ny] == 1) continue;
+
+				q.push({ nx,ny });
+				visit[nx][ny] = true;
+			}
+		}
+	}
+	cout << "-1\n";
+}
+
+void cantMove() {
+	for (int t = 1; !mq.empty() && t <= K; t++) {
+		int qsize = mq.size();
+		while (qsize--) {
+			int x = mq.front().first;
+			int y = mq.front().second;
+			mq.pop();
+
+			for (int d = 0; d < 4; d++) {
+				int nx = x + direct[d][0];
+				int ny = y + direct[d][1];
+
+				if (nx < 0 || ny < 0 || nx >= N || ny >= M) continue;
+				if (visit[nx][ny]) continue;
+
+				mq.push({ nx,ny });
+				visit[nx][ny] = true;
+			}
+		}
+	}
+}
+
+void input() {
+	cin >> N >> M >> K;
+	for (int i = 0; i < N; i++) {
+		for (int j = 0; j < M; j++) {
+			cin >> list[i][j];
+			if (list[i][j] == 4) {
+				q.push({ i,j });
+				visit[i][j] = true;
+			}
+			else if (list[i][j] == 3) {
+				mq.push({ i,j });
+				visit[i][j] = true;
+			}
+		}
+	}
+
+	cantMove();
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
bfs

## 풀이 방법
1. `list[i][j] == 4`이면 q에 좌표를 넣고, 방문처리를 한다.
2. `list[i][j] == 3`이면 mq에 좌표를 넣고, 방문처리를 한다.
3. 마네킹의 좌표를 담은 mq에 있는 좌표들을 꺼내 bfs로 K만큼 이동한다.
   + 마네킹과 시루가 이동하기 위한 방문 처리는 같은 visit배열을 사용한다.
   + 어차피 마네킹과 K 이하의 거리에 가지 못한다.
4. 시루가 의자에 갈 수 있는 최단거리를 bfs로 구한다.
5. 의자에 갈 수 없다면 `-1`을 출력한다.
