### PR TITLE
boj 8979 올림픽

### DIFF
--- a/구현/8979.cpp
+++ b/구현/8979.cpp
@@ -1,0 +1,51 @@
+#include <iostream>
+#define MAX 1001
+using namespace std;
+
+typedef struct Point {
+	int x;
+	int y;
+	int z;
+}Point;
+
+Point list[MAX];
+int N, K;
+
+void func() {
+	int ret = 1;
+	for (int i = 1; i <= N; i++) {
+		if (i == K) continue;
+		if (list[K].x != list[i].x) {
+			ret += (list[K].x < list[i].x);
+			continue;
+		}
+		if (list[K].y != list[i].y) {
+			ret += (list[K].y < list[i].y);
+			continue;
+		}
+		if (list[K].z != list[i].z) {
+			ret += (list[K].z < list[i].z);
+		}
+	}
+
+	cout << ret << '\n';
+}
+
+void input() {
+	int idx, x, y, z;
+	cin >> N >> K;
+	for (int i = 0; i < N; i++) {
+		cin >> idx >> x >> y >> z;
+		list[idx] = { x,y,z };
+	}
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
implementation

## 풀이 방법
K번 국가보다 금메달, 은메달, 동메달 순으로 더 많은 메달을 가진 국가의 갯수 + 1을 출력한다.
   + 갯수가 모두 같으면 카운팅을 하지 않는다.
