### PR TITLE
boj 25307 시루의 백화점 구경

### DIFF
--- a/bfs/25307.cpp
+++ b/bfs/25307.cpp
@@ -14,6 +14,7 @@ int direct[4][2] = { {0,1},{1,0},{0,-1},{-1,0} };
 int N, M, K;
 
 void func() {
+	visit[q.front().first][q.front().second] = true;
 	for (int t = 0; !q.empty(); t++) {
 		int qsize = q.size();
 		while (qsize--) {
@@ -70,7 +71,6 @@ void input() {
 			cin >> list[i][j];
 			if (list[i][j] == 4) {
 				q.push({ i,j });
-				visit[i][j] = true;
 			}
 			else if (list[i][j] == 3) {
 				mq.push({ i,j });


### PR DESCRIPTION
## 알고리즘 분류
bfs

## 풀이 방법
시작 지점이 사전에 방문처리되어 거리가 K 이하인 지점을 제대로 구하지 못하는 부분 수정

