### PR TITLE
boj 25682 체스판 다시 칠하기 2

### DIFF
--- a/dp/25682.cpp
+++ b/dp/25682.cpp
@@ -1,0 +1,66 @@
+#include <iostream>
+#include <algorithm>
+#define MAX 2001
+using namespace std;
+
+char list[MAX][MAX];
+int bdp[MAX][MAX], wdp[MAX][MAX];
+int N, M, K;
+
+void getPrefixSum() {
+	for (int i = 1; i <= N; i++) {
+		for (int j = 1; j <= M; j++) {
+			bdp[i][j] = bdp[i - 1][j] + bdp[i][j - 1] - bdp[i - 1][j - 1];
+			wdp[i][j] = wdp[i - 1][j] + wdp[i][j - 1] - wdp[i - 1][j - 1];
+
+			if (list[i][j] == 'W') {
+				if ((i + j) % 2) {
+					wdp[i][j]++;
+				}
+				else {
+					bdp[i][j]++;
+				}
+			}
+			else {
+				if ((i + j) % 2) {
+					bdp[i][j]++;
+				}
+				else {
+					wdp[i][j]++;
+				}
+			}
+		}
+	}
+}
+
+void func() {
+	getPrefixSum();
+	int ret = 2147483647;
+	for (int i = K; i <= N; i++) {
+		for (int j = K; j <= M; j++) {
+			ret = min(ret, bdp[i][j] - bdp[i - K][j] - bdp[i][j - K] + bdp[i - K][j - K]);
+			ret = min(ret, wdp[i][j] - wdp[i - K][j] - wdp[i][j - K] + wdp[i - K][j - K]);
+		}
+	}
+
+	cout << ret << '\n';
+}
+
+void input() {
+	cin >> N >> M >> K;
+	for (int i = 1; i <= N; i++) {
+		for (int j = 1; j <= M; j++) {
+			cin >> list[i][j];
+		}
+	}
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
dp, prefix sum

## 풀이 방법
1. `black`이 먼저 칠해질 경우, `white`가 먼저 칠해질 경우의 dp 값을 구한다.
   + 점화식은 `dp[i][j] = dp[i - 1][j] + dp[i][j - 1] - dp[i - 1][j - 1] + (원하는 색이 아닐경우 1)`이다.
2. 시작 점인 (1, 1) ~ (K, K)부터 구간 누적합의 최소를 구해 출력한다.
