### PR TITLE
boj 12841 정보대 등산

### DIFF
--- a/dp/12841.cpp
+++ b/dp/12841.cpp
@@ -1,0 +1,50 @@
+#include <iostream>
+#define MAX 100001
+using namespace std;
+typedef long long ll;
+typedef pair<ll, ll> pii;
+
+pii dp[MAX];
+ll cross[MAX];
+int N;
+
+void func() {
+	int idx = 0;
+	ll ret = 1e12;
+	for (int i = 1; i <= N; i++) {
+		ll sum = cross[i] + dp[i - 1].first + dp[N - 1].second - dp[i - 1].second;
+		if (ret > sum) {
+			idx = i;
+			ret = sum;
+		}
+	}
+
+	cout << idx << ' ' << ret << '\n';
+}
+
+void input() {
+	cin >> N;
+	for (int i = 1; i <= N; i++) {
+		cin >> cross[i];
+	}
+
+	for (int i = 1; i < N; i++) {
+		cin >> dp[i].first;
+		dp[i].first += dp[i - 1].first;
+	}
+
+	for (int i = 1; i < N; i++) {
+		cin >> dp[i].second;
+		dp[i].second += dp[i - 1].second;
+	}
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
dp

## 풀이 방법
`dp[i].first: 왼쪽 길의 누적 합`
`dp[i].second: 오른쪽 길의 누적 합`
1. 각 방향에 있는 길의 누적 합을 구한다.
2. i번 횡단보도의 길이와 왼쪽에서는 i - 1번까지, 오른쪽에서는 i ~ N번 까지의 누적합을 더한다.
   - `cross[i] + dp[i - 1].first + (dp[N - 1].second - dp[i - 1].second)`
3. 2에서 구한 값들의 최소를 갱신하여 인덱스와 함께 출력한다.
