### PR TITLE
boj 11561 징검다리

### DIFF
--- a/binarysearch/11561.cpp
+++ b/binarysearch/11561.cpp
@@ -1,0 +1,42 @@
+#include <iostream>
+#include <algorithm>
+using namespace std;
+typedef unsigned long long ull;
+
+ull N;
+
+void func() {
+	ull l = 1LL;
+	ull r = N;
+	ull ret = 0;
+	while (l <= r) {
+		ull m = (l + r) / 2LL;
+		if (m * (m + 1) <= N * 2LL) {
+			ret = max(ret, m);
+			l = m + 1;
+		}
+		else {
+			r = m - 1;
+		}
+	}
+
+	cout << ret << '\n';
+}
+
+void input() {
+	cin >> N;
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	int tc;
+	cin >> tc;
+	while (tc--) {
+		input();
+		func();
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
parametric search

## 풀이 방법
`l ~ r`: 건널 징검다리 갯수
1. m개의 징검다리를 건널 때 총 이동거리가 N보다 작거나 같으면 ret을 갱신한다.
   + m개의 징검다리를 1, 2, 3, 4.. m칸으로 이동했을 때 총 이동한 거리는 `m * (m + 1) / 2`가 된다.
   + `m * (m + 1) <= N * 2`이면 m번의 움직임으로 N 이하를 충분히 움직일 수 있다.
