### PR TITLE
boj 27465 소수가 아닌 수

### DIFF
--- a/ad-hoc/27465.cpp
+++ b/ad-hoc/27465.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+using namespace std;
+
+int N;
+
+void func() {
+	cout << "1000000000\n";
+}
+
+void input() {
+	cin >> N;
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
ad-hoc

## 풀이 방법
`1000000000`을 출력한다.
