### PR TITLE
boj 2891 카약과 강풍

### DIFF
--- a/greedy/2891.cpp
+++ b/greedy/2891.cpp
@@ -1,0 +1,51 @@
+#include <iostream>
+#define MAX 12
+using namespace std;
+
+int cnt[MAX];
+int N, S, R;
+
+void func() {
+	int ret = 0;
+	for (int i = 1; i <= N; i++) {
+		if (!cnt[i]) continue;
+
+		if (cnt[i] == -1) {
+			if (cnt[i - 1] == 1) {
+				cnt[i - 1]--;
+				cnt[i]++;
+			}
+			else if (cnt[i + 1] == 1) {
+				cnt[i + 1]--;
+				cnt[i]++;
+			}
+			else ret++;
+		}
+	}
+
+	cout << ret << '\n';
+}
+
+void input() {
+	int x;
+	cin >> N >> S >> R;
+	for (int i = 0; i < S; i++) {
+		cin >> x;
+		cnt[x]--;
+	}
+
+	for (int i = 0; i < R; i++) {
+		cin >> x;
+		cnt[x]++;
+	}
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
greedy

## 풀이 방법
1. 카약이 손상된 팀과 하나 더 보유한 팀을 카운팅한다.
2. i번 팀의 카약이 부족하다면 i - 1, i + 1번 팀에서 카약을 가져올 수 있는지 확인한다.
   + 가져올 수 있다면 카운팅을 수정한다.
   + 가져올 수 없다면 ret을 카운팅한다.
