### PR TITLE
boj 17258 인기가 넘쳐흘러

### DIFF
--- a/dp/17258.cpp
+++ b/dp/17258.cpp
@@ -1,0 +1,62 @@
+#include <iostream>
+#include <cstring>
+#include <algorithm>
+#define MAX 310
+using namespace std;
+
+int dp[MAX][MAX][MAX];
+int sum[MAX];
+int N, M, K, T;
+
+int solve(int idx, int k, int pre) {
+	if (idx == N + 1) return 0;
+
+	int& ret = dp[idx][k][pre];
+	if (ret != -1) return ret;
+
+	if (sum[idx] >= T) {
+		return ret = solve(idx + 1, k, 0) + 1;
+	}
+	if (sum[idx] + pre >= T) {
+		return ret = solve(idx + 1, k, pre) + 1;
+	}
+
+	ret = solve(idx + 1, k, pre);
+	int tmp = T - (sum[idx] + pre);
+	if (tmp <= k) {
+		ret = max(ret, solve(idx + 1, k - tmp, pre + tmp) + 1);
+	}
+	return ret;
+}
+
+void init() {
+	memset(dp, -1, sizeof(dp));
+	for (int i = 1; i < MAX; i++) {
+		sum[i] += sum[i - 1];
+	}
+}
+
+void func() {
+	init();
+	cout << solve(1, K, 0) << '\n';
+}
+
+void input() {
+	int l, r;
+	cin >> N >> M >> K >> T;
+	while (M--) {
+		cin >> l >> r;
+		sum[l]++;
+		sum[r]--;
+	}
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
dp, prefix sum

## 풀이 방법
`dp[N][K][pre]: N 시간에 친구 K명을 부를 수 있고, 파티에 참여중인 친구가 pre명일 때 파티에 머무르는 최대 시간`
1. 파티에 참여하는 사람들의 시간별 누적합을 구한다.
2. `sum[idx] >= T`일 때 시간을 1 추가하고 pre = 0으로 만든다.
3. `sum[idx] + pre >= T`일 때 시간을 1 추가하고 친구의 수는 변화 없이 다음으로 넘긴다.
4. 친구를 tmp명 추가했을 때 파티에 머무를 수 있다면 해당 경우의 최대도 구한다.
