### PR TITLE
boj 10350 Banks

### DIFF
--- a/ad-hoc/10350.cpp
+++ b/ad-hoc/10350.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <cmath>
+#define MAX 20001
+using namespace std;
+typedef long long ll;
+
+int dp[MAX];
+int N;
+
+void init() {
+	for (int i = 1; i <= (N << 1); i++) {
+		dp[i] += dp[i - 1];
+	}
+}
+
+void func() {
+	init();
+
+	ll ret = 0;
+	for (int i = 1; i <= N; i++) {
+		for (int j = i; j < N + i; j++) {
+			if (dp[j] - dp[i - 1] >= 0) continue;
+			ret += (ll)ceil((double)(-dp[j] + dp[i - 1]) / (double)(dp[N + i - 1] - dp[i - 1]));
+		}
+	}
+	cout << ret << '\n';
+}
+
+void input() {
+	cin >> N;
+	for (int i = 1; i <= N; i++) {
+		cin >> dp[i];
+		dp[i + N] = dp[i];
+	}
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
ad-hoc, dp, prefix sum

## 풀이 방법
1. 1 ~ 2N의 누적합을 구한다.
2. i ~ j까지의 합이 음수일 경우 횟수를 카운팅한다.
   + `i ~ j 범위의 합 / i번부터 N개의 전체 누적합`의 올림 값을 더한다.
