### PR TITLE
boj 9082 지뢰찾기

### DIFF
--- a/greedy/9082.cpp
+++ b/greedy/9082.cpp
@@ -1,0 +1,58 @@
+#include <iostream>
+#define MAX 101
+using namespace std;
+
+char list[2][MAX];
+int direct[3] = { 1,0,-1 };
+int N;
+
+void func() {
+	int ret = 0;
+	for (int i = 0; i < N; i++) {
+		ret += (list[1][i] == '*');
+	}
+
+	for (int i = 0; i < N; i++) {
+		int cnt = list[0][i] - '0';
+		if (!cnt) continue;
+		for (int d = 0; d < 3; d++) {
+			if (!cnt) break;
+			int ni = i + direct[d];
+
+			if (ni < 0 || ni >= N) continue;
+			cnt -= (list[1][ni] == '*');
+		}
+
+		for (int d = 0; d < 3; d++) {
+			if (!cnt) break;
+			int ni = i + direct[d];
+
+			if (ni < 0 || ni >= N) continue;
+			if (list[1][ni] != '#') continue;
+
+			list[1][ni] = '*';
+			ret++;
+			cnt--;
+		}
+	}
+
+	cout << ret << '\n';
+}
+
+void input() {
+	cin >> N >> list[0] >> list[1];
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	int tc;
+	cin >> tc;
+	while (tc--) {
+		input();
+		func();
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
greedy

## 풀이 방법
1. 이미 확정된 지뢰의 갯수를 카운팅한다.
2. 첫번째 숫자부터 순회하여 주변에 이미 매설된 지뢰의 갯수를 카운팅한다.
3. 2에서 구한 만큼을 제외하고 남은 지뢰를 1, 0, -1 순으로 매설하면서 카운팅한다.
