### PR TITLE
boj 16161 가장 긴 증가하는 팰린드롬 부분수열

### DIFF
--- a/ad-hoc/16161.cpp
+++ b/ad-hoc/16161.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <algorithm>
+#define MAX 100001
+using namespace std;
+
+int list[MAX];
+int N;
+
+void func() {
+	int l = 0;
+	int ret = 1;
+	while (l < N) {
+		int r = l;
+		if (r + 1 < N && list[l] == list[r + 1]) r++;
+
+		int s = l - 1;
+		int e = r + 1;
+		while (s >= 0 && e < N) {
+			if (list[s] != list[e] || list[s] >= list[s + 1]) break;
+			e++;
+			s--;
+		}
+
+		ret = max(ret, e - s - 1);
+		l = e;
+	}
+	cout << ret << '\n';
+}
+
+void input() {
+	cin >> N;
+	for (int i = 0; i < N; i++) {
+		cin >> list[i];
+	}
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
ad-hoc

## 풀이 방법
1. l = 0부터 시작하여 증가하는 팰린드롬의 길이를 구한다.
   + l, r은 중간 지점을 나타내는 인덱스
2. `list[l] == list[r + 1]`이면 r의 범위를 1 늘린다.
3. 그 다음 수가 이전 수보다 크면 팰린드롬으로 포함시킨다.
4. 중앙 값이 `l ~ r`일 때 팰린드롬의 길이를 구했으면 l을 e 값으로 변경한다.
