### PR TITLE
boj 3231 카드놀이

### DIFF
--- a/ad-hoc/3231.cpp
+++ b/ad-hoc/3231.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#define MAX 100001
+using namespace std;
+
+int list[MAX];
+int N;
+
+void func() {
+	int ret = 0;
+	for (int i = 2; i <= N; i++) {
+		ret += (list[i] < list[i - 1]);
+	}
+	cout << ret << '\n';
+}
+
+void input() {
+	int x;
+	cin >> N;
+	for (int i = 0; i < N; i++) {
+		cin >> x;
+		list[x] = i;
+	}
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
ad-hoc

## 풀이 방법
1. 배열에 카드의 위치를 저장한다.
2. 배열을 순회하면서 `list[i] < list[i - 1]`인 경우를 카운팅한다.
