### PR TITLE
boj 1027 고층 건물

### DIFF
--- a/브루트포스/1027.cpp
+++ b/브루트포스/1027.cpp
@@ -1,0 +1,62 @@
+#include <iostream>
+#define MAX 50
+using namespace std;
+typedef long long ll;
+
+int list[MAX];
+int N;
+
+ll ccw(ll x, ll y, ll z) {
+	return x * (list[y] - list[z]) + y * (list[z] - list[x]) + z * (list[x] - list[y]);
+}
+
+void func() {
+	if (N < 3) {
+		cout << N - 1 << '\n';
+		return;
+	}
+
+	int ret = 0;
+	for (int i = 0; i < N; i++) {
+		int cnt = 0;
+		if (i > 0) {
+			int pre = i - 1;
+			cnt++;
+			for (int j = i - 2; j >= 0; j--) {
+				if (ccw(i, pre, j) >= 0) continue;
+				cnt++;
+				pre = j;	
+			}
+		}
+
+		if (i < N - 1) {
+			int pre = i + 1;
+			cnt++;
+			for (int j = i + 2; j < N; j++) {
+				if (ccw(i, pre, j) <= 0) continue;
+				cnt++;
+				pre = j;
+			}
+		}
+
+		ret = max(ret, cnt);
+	}
+	cout << ret << '\n';
+}
+
+void input() {
+	cin >> N;
+	for (int i = 0; i < N; i++) {
+		cin >> list[i];
+	}
+}
+
+int main() {
+	cin.tie(NULL); cout.tie(NULL);
+	ios::sync_with_stdio(false);
+
+	input();
+	func();
+
+	return 0;
+}


### PR DESCRIPTION
## 알고리즘 분류
bruteforce, ccw

## 풀이 방법
1. 바로 옆의 빌딩은 볼 수 있으므로 추가한다.
2. 왼쪽, 오른쪽 순서대로 볼 수 있는 빌딩의 수를 구한다.
3. 3개의 빌딩을 선으로 그엇을 때 아래로 볼록한 경우의 수를 카운팅한다.
   + 순서는 i번째 빌딩, 가장 마지막에 확인한 볼 수 있는 빌딩, j번째 빌딩으로 ccw 값을 계산
   + 왼쪽의 경우 ccw가 음수인 경우를 카운팅한다.
   + 오른쪽의 경우 ccw가 양수인 경우를 카운팅한다.
